### PR TITLE
prepublish hook doesn't seem to work when used as a git dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A fully mocked and test-friendly version of react native",
   "main": "build/react-native.js",
   "scripts": {
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "test": "npm run lint && npm run mocha",
     "mocha": "mocha --require babel-core/register 'test/**/*.js'",
     "mocha:watch": "npm run test -- --watch",


### PR DESCRIPTION
Switch to `prepare` instead